### PR TITLE
Allow user to cancel the search by hitting 'Escape'

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,9 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.window.showInputBox({
 			prompt: 'What do you want to search for?'
 		}).then((result) => {
-			open('http://stackoverflow.com/search?q=' + result);
+			if(result){
+				open('http://stackoverflow.com/search?q=' + result);
+			}
 		});
 	});
 	
@@ -32,7 +34,9 @@ export function activate(context: vscode.ExtensionContext) {
 		
 		//Use the node module "open" to open a web browser
 		let output = selection.getStringFromSelection(thisSelection, textEdtior.document);
-		open('http://stackoverflow.com/search?q='+output);
+		if(output && output.trim.length > 0){
+			open('http://stackoverflow.com/search?q='+output);
+		}
 	});
 
 	context.subscriptions.push(search);


### PR DESCRIPTION
The prompt the user sees tells them they can hit 'Escape' to cancel but if I hit escape it does a search for undefined. If I do a selection search on an empty value it does a search for %20.

This is a simple change that checks the values either from the selection or prompt and does not open the browser if they are empty.
